### PR TITLE
Add category count sorting to summary

### DIFF
--- a/features/summary/api/use-get-summary.ts
+++ b/features/summary/api/use-get-summary.ts
@@ -9,15 +9,19 @@ export const useGetSummary = () => {
   const from = params.get('from') || '';
   const to = params.get('to') || '';
   const accountId = params.get('accountId') || '';
+  const sort = params.get('sort') || 'amount';
+  const limit = params.get('limit') || '';
 
   const query = useQuery({
-    queryKey: ['summary', { from, to, accountId }],
+    queryKey: ['summary', { from, to, accountId, sort, limit }],
     queryFn: async () => {
       const response = await client.api.summary.$get({
         query: {
           from,
           to,
           accountId,
+          sort,
+          limit,
         },
       });
 


### PR DESCRIPTION
## Summary
- compute category usage count in summary query
- support sorting by amount or count and custom category limit
- pass sort and limit params from useGetSummary

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bd9370f0832b8cd5d5e59548abf4