### PR TITLE
Add chart export capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A full-stack personal finance management application built with React (frontend)
 - Track income and expenses
 - View transaction history
 - Visualize income vs. expenses with interactive charts
+- Export charts as PNG or PDF
 - Add, edit, and delete transactions
 - Unit tests for both backend and frontend components
 
@@ -96,6 +97,7 @@ A full-stack personal finance management application built with React (frontend)
 1. Launch backend and frontend as described above.
 2. Open `http://localhost:3000` in your browser.
 3. Add income or expense transactions, view history, and analyze charts.
+4. Use the export button on each chart to download it as PNG or PDF.
 
 ## Conventions
 See [`CONVENTIONS.md`](CONVENTIONS.md) for coding style, branch naming, and commit message guidelines.

--- a/components/chart.tsx
+++ b/components/chart.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import {
   AreaChart,
   BarChart3,
   FileSearch,
   LineChart,
   Loader2,
+  Download,
+  FileText,
 } from "lucide-react";
 
 import { usePaywall } from "@/features/subscriptions/hooks/use-paywall";
@@ -13,7 +15,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { BarVariant } from "@/components/bar-variant";
 import { AreaVariant } from "@/components/area-variant";
 import { LineVariant } from "@/components/line-variant";
+import { toast } from "sonner";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -21,6 +26,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import { toPng } from "html-to-image";
+import jsPDF from "jspdf";
 
 type Props = {
   data?: {
@@ -32,7 +46,38 @@ type Props = {
 
 export const Chart = ({ data = [] }: Props) => {
   const [chartType, setChartType] = useState("area");
+  const containerRef = useRef<HTMLDivElement>(null);
   const { shouldBlock, triggerPaywall } = usePaywall();
+
+  const exportAsPng = async () => {
+    if (!containerRef.current) return;
+    try {
+      const dataUrl = await toPng(containerRef.current);
+      const link = document.createElement("a");
+      link.download = "chart.png";
+      link.href = dataUrl;
+      link.click();
+      toast.success("Exported as PNG");
+    } catch {
+      toast.error("Failed to export chart");
+    }
+  };
+
+  const exportAsPdf = async () => {
+    if (!containerRef.current) return;
+    try {
+      const dataUrl = await toPng(containerRef.current);
+      const pdf = new jsPDF({ orientation: "landscape" });
+      const imgProps = pdf.getImageProperties(dataUrl);
+      const pdfWidth = pdf.internal.pageSize.getWidth();
+      const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+      pdf.addImage(dataUrl, "PNG", 0, 0, pdfWidth, pdfHeight);
+      pdf.save("chart.pdf");
+      toast.success("Exported as PDF");
+    } catch {
+      toast.error("Failed to export chart");
+    }
+  };
 
   const onTypeChange = (type: string) => {
     if (type !== "area" && shouldBlock) {
@@ -43,35 +88,53 @@ export const Chart = ({ data = [] }: Props) => {
   };
 
   return (
-    <Card className="border-none drop-shadow-sm">
+    <Card ref={containerRef} className="border-none drop-shadow-sm">
       <CardHeader className="flex space-y-2 lg:space-y-0 lg:flex-row lg:items-center justify-between">
         <CardTitle className="text-xl line-clamp-1">Transactions</CardTitle>
-        <Select defaultValue={chartType} onValueChange={onTypeChange}>
-          <SelectTrigger className="lg:w-auto h-9 rounded-md px-3">
-            <SelectValue placeholder="Chart type" />
-          </SelectTrigger>
+        <div className="flex items-center gap-2">
+          <Select defaultValue={chartType} onValueChange={onTypeChange}>
+            <SelectTrigger className="lg:w-auto h-9 rounded-md px-3">
+              <SelectValue placeholder="Chart type" />
+            </SelectTrigger>
 
-          <SelectContent>
-            <SelectItem value="area">
-              <div className="flex items-center">
-                <AreaChart className="size-4 mr-2 shrink-0" />
-                <p className="line-clamp-1">Area Chart</p>
-              </div>
-            </SelectItem>
-            <SelectItem value="line">
-              <div className="flex items-center">
-                <LineChart className="size-4 mr-2 shrink-0" />
-                <p className="line-clamp-1">Line Chart {shouldBlock && "🔒"}</p>
-              </div>
-            </SelectItem>
-            <SelectItem value="bar">
-              <div className="flex items-center">
-                <BarChart3 className="size-4 mr-2 shrink-0" />
-                <p className="line-clamp-1">Bar Chart {shouldBlock && "🔒"}</p>
-              </div>
-            </SelectItem>
-          </SelectContent>
-        </Select>
+            <SelectContent>
+              <SelectItem value="area">
+                <div className="flex items-center">
+                  <AreaChart className="size-4 mr-2 shrink-0" />
+                  <p className="line-clamp-1">Area Chart</p>
+                </div>
+              </SelectItem>
+              <SelectItem value="line">
+                <div className="flex items-center">
+                  <LineChart className="size-4 mr-2 shrink-0" />
+                  <p className="line-clamp-1">Line Chart {shouldBlock && "🔒"}</p>
+                </div>
+              </SelectItem>
+              <SelectItem value="bar">
+                <div className="flex items-center">
+                  <BarChart3 className="size-4 mr-2 shrink-0" />
+                  <p className="line-clamp-1">Bar Chart {shouldBlock && "🔒"}</p>
+                </div>
+              </SelectItem>
+            </SelectContent>
+          </Select>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <Download className="size-4 mr-1" /> Export
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={exportAsPng}>
+                <Download className="size-4 mr-2" /> PNG
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={exportAsPdf}>
+                <FileText className="size-4 mr-2" /> PDF
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </CardHeader>
 
       <CardContent>

--- a/components/spending-pie.tsx
+++ b/components/spending-pie.tsx
@@ -1,11 +1,14 @@
-import { useState } from "react";
-import { FileSearch, Loader2, PieChart, Radar, Target } from "lucide-react";
+import { useState, useRef } from "react";
+import { FileSearch, Loader2, PieChart, Radar, Target, Download, FileText } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { PieVariant } from "@/components/pie-variant";
 import { RadarVariant } from "@/components/radar-variant";
 import { RadialVariant } from "@/components/radial-variant";
+import { toast } from "sonner";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -13,6 +16,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import { toPng } from "html-to-image";
+import jsPDF from "jspdf";
 
 type Props = {
   data?: {
@@ -23,41 +35,90 @@ type Props = {
 
 export const SpendingPie = ({ data = [] }: Props) => {
   const [chartType, setChartType] = useState("pie");
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const onTypeChange = (type: string) => {
     setChartType(type);
   };
 
+  const exportAsPng = async () => {
+    if (!containerRef.current) return;
+    try {
+      const dataUrl = await toPng(containerRef.current);
+      const link = document.createElement("a");
+      link.download = "chart.png";
+      link.href = dataUrl;
+      link.click();
+      toast.success("Exported as PNG");
+    } catch {
+      toast.error("Failed to export chart");
+    }
+  };
+
+  const exportAsPdf = async () => {
+    if (!containerRef.current) return;
+    try {
+      const dataUrl = await toPng(containerRef.current);
+      const pdf = new jsPDF({ orientation: "landscape" });
+      const imgProps = pdf.getImageProperties(dataUrl);
+      const pdfWidth = pdf.internal.pageSize.getWidth();
+      const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+      pdf.addImage(dataUrl, "PNG", 0, 0, pdfWidth, pdfHeight);
+      pdf.save("chart.pdf");
+      toast.success("Exported as PDF");
+    } catch {
+      toast.error("Failed to export chart");
+    }
+  };
+
   return (
-    <Card className="border-none drop-shadow-sm">
+    <Card ref={containerRef} className="border-none drop-shadow-sm">
       <CardHeader className="flex space-y-2 lg:space-y-0 lg:flex-row lg:items-center justify-between">
         <CardTitle className="text-xl line-clamp-1">Categories</CardTitle>
-        <Select defaultValue={chartType} onValueChange={onTypeChange}>
-          <SelectTrigger className="lg:w-auto h-9 rounded-md px-3">
-            <SelectValue placeholder="Chart type" />
-          </SelectTrigger>
+        <div className="flex items-center gap-2">
+          <Select defaultValue={chartType} onValueChange={onTypeChange}>
+            <SelectTrigger className="lg:w-auto h-9 rounded-md px-3">
+              <SelectValue placeholder="Chart type" />
+            </SelectTrigger>
 
-          <SelectContent>
-            <SelectItem value="pie">
-              <div className="flex items-center">
-                <PieChart className="size-4 mr-2 shrink-0" />
-                <p className="line-clamp-1">Pie Chart</p>
-              </div>
-            </SelectItem>
-            <SelectItem value="radar">
-              <div className="flex items-center">
-                <Radar className="size-4 mr-2 shrink-0" />
-                <p className="line-clamp-1">Radar Chart</p>
-              </div>
-            </SelectItem>
-            <SelectItem value="radial">
-              <div className="flex items-center">
-                <Target className="size-4 mr-2 shrink-0" />
-                <p className="line-clamp-1">Radial Chart</p>
-              </div>
-            </SelectItem>
-          </SelectContent>
-        </Select>
+            <SelectContent>
+              <SelectItem value="pie">
+                <div className="flex items-center">
+                  <PieChart className="size-4 mr-2 shrink-0" />
+                  <p className="line-clamp-1">Pie Chart</p>
+                </div>
+              </SelectItem>
+              <SelectItem value="radar">
+                <div className="flex items-center">
+                  <Radar className="size-4 mr-2 shrink-0" />
+                  <p className="line-clamp-1">Radar Chart</p>
+                </div>
+              </SelectItem>
+              <SelectItem value="radial">
+                <div className="flex items-center">
+                  <Target className="size-4 mr-2 shrink-0" />
+                  <p className="line-clamp-1">Radial Chart</p>
+                </div>
+              </SelectItem>
+            </SelectContent>
+          </Select>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <Download className="size-4 mr-1" /> Export
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={exportAsPng}>
+                <Download className="size-4 mr-2" /> PNG
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={exportAsPdf}>
+                <FileText className="size-4 mr-2" /> PDF
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </CardHeader>
 
       <CardContent>


### PR DESCRIPTION
## Summary
- add export dropdown in `Chart` and `SpendingPie`
- use `html-to-image` and `jsPDF` for PNG/PDF generation
- show toast on success or error
- document chart export feature in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bd974e7c832b804def8f4f8f4ae4