### PR TITLE
Add customizable chart colors

### DIFF
--- a/components/__tests__/pie-variant.test.tsx
+++ b/components/__tests__/pie-variant.test.tsx
@@ -1,0 +1,12 @@
+import renderer from "react-test-renderer";
+import { PieVariant } from "../pie-variant";
+
+describe("PieVariant colors", () => {
+  it("uses custom colors when provided", () => {
+    const tree = renderer.create(
+      <PieVariant data={[{ name: "a", value: 1 }]} colors={["#111111"]} />,
+    );
+    const cell = tree.root.findByProps({ fill: "#111111" });
+    expect(cell).toBeTruthy();
+  });
+});

--- a/components/chart-colors.ts
+++ b/components/chart-colors.ts
@@ -1,0 +1,9 @@
+export const CHART_PALETTES = {
+  default: ["#0062FF", "#12C6FF", "#FF647F", "#FF9354"],
+  pastel: ["#A0E7E5", "#B4F8C8", "#FFAEBC", "#FBE7C6"],
+  warm: ["#FF6B6B", "#FF9F43", "#FFC75F", "#F9F871"],
+} as const;
+
+export type PaletteName = keyof typeof CHART_PALETTES;
+
+export const DEFAULT_CHART_COLORS = CHART_PALETTES.default;

--- a/components/pie-variant.tsx
+++ b/components/pie-variant.tsx
@@ -5,21 +5,21 @@ import {
   PieChart,
   ResponsiveContainer,
   Tooltip,
-} from 'recharts';
+} from "recharts";
 
-import { formatPercentage } from '@/lib/utils';
-import { CategoryTooltip } from '@/components/category-tooltip';
-
-const COLORS = ['#0062FF', '#12C6FF', '#FF647F', '#FF9354'];
+import { formatPercentage } from "@/lib/utils";
+import { CategoryTooltip } from "@/components/category-tooltip";
+import { DEFAULT_CHART_COLORS } from "@/components/chart-colors";
 
 type Props = {
   data: {
     name: string;
     value: number;
   }[];
+  colors?: string[];
 };
 
-export const PieVariant = ({ data }: Props) => {
+export const PieVariant = ({ data, colors = DEFAULT_CHART_COLORS }: Props) => {
   return (
     <ResponsiveContainer width="100%" height={350}>
       <PieChart>
@@ -67,7 +67,7 @@ export const PieVariant = ({ data }: Props) => {
           labelLine={false}
         >
           {data.map((_entry, index) => (
-            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+            <Cell key={`cell-${index}`} fill={colors[index % colors.length]} />
           ))}
         </Pie>
       </PieChart>

--- a/components/radar-variant.tsx
+++ b/components/radar-variant.tsx
@@ -5,28 +5,24 @@ import {
   Radar,
   RadarChart,
   ResponsiveContainer,
-} from 'recharts';
+} from "recharts";
 
 type Props = {
   data: {
     name: string;
     value: number;
   }[];
+  color?: string;
 };
 
-export const RadarVariant = ({ data }: Props) => {
+export const RadarVariant = ({ data, color = "#3b82f6" }: Props) => {
   return (
     <ResponsiveContainer width="100%" height={350}>
       <RadarChart cx="50%" cy="50%" outerRadius="60%" data={data}>
         <PolarGrid />
-        <PolarAngleAxis style={{ fontSize: '12px' }} dataKey="name" />
-        <PolarRadiusAxis style={{ fontSize: '12px' }} />
-        <Radar
-          dataKey="value"
-          stroke="#3b82f6"
-          fill="#3b82f6"
-          fillOpacity={0.6}
-        />
+        <PolarAngleAxis style={{ fontSize: "12px" }} dataKey="name" />
+        <PolarRadiusAxis style={{ fontSize: "12px" }} />
+        <Radar dataKey="value" stroke={color} fill={color} fillOpacity={0.6} />
       </RadarChart>
     </ResponsiveContainer>
   );

--- a/components/radial-variant.tsx
+++ b/components/radial-variant.tsx
@@ -3,21 +3,24 @@ import {
   RadialBarChart,
   Legend,
   ResponsiveContainer,
-} from 'recharts';
+} from "recharts";
 
-import { formatCurrency } from '@/lib/utils';
-import { CategoryTooltip } from '@/components/category-tooltip';
-
-const COLORS = ['#0062FF', '#12C6FF', '#FF647F', '#FF9354'];
+import { formatCurrency } from "@/lib/utils";
+import { CategoryTooltip } from "@/components/category-tooltip";
+import { DEFAULT_CHART_COLORS } from "@/components/chart-colors";
 
 type Props = {
   data: {
     name: string;
     value: number;
   }[];
+  colors?: string[];
 };
 
-export const RadialVariant = ({ data }: Props) => {
+export const RadialVariant = ({
+  data,
+  colors = DEFAULT_CHART_COLORS,
+}: Props) => {
   return (
     <ResponsiveContainer width="100%" height={350}>
       <RadialBarChart
@@ -28,14 +31,14 @@ export const RadialVariant = ({ data }: Props) => {
         outerRadius="40%"
         data={data.map((item, index) => ({
           ...item,
-          fill: COLORS[index % COLORS.length],
+          fill: colors[index % colors.length],
         }))}
       >
         <RadialBar
           label={{
-            position: 'insideStart',
-            fill: '#fff',
-            fontSize: '12px',
+            position: "insideStart",
+            fill: "#fff",
+            fontSize: "12px",
           }}
           background
           dataKey="value"

--- a/components/spending-pie.tsx
+++ b/components/spending-pie.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PieVariant } from "@/components/pie-variant";
 import { RadarVariant } from "@/components/radar-variant";
 import { RadialVariant } from "@/components/radial-variant";
+import { CHART_PALETTES, PaletteName } from "@/components/chart-colors";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
@@ -23,41 +24,72 @@ type Props = {
 
 export const SpendingPie = ({ data = [] }: Props) => {
   const [chartType, setChartType] = useState("pie");
+  const [palette, setPalette] = useState<PaletteName>("default");
 
   const onTypeChange = (type: string) => {
     setChartType(type);
   };
 
+  const onPaletteChange = (value: string) => {
+    setPalette(value as PaletteName);
+  };
+
   return (
     <Card className="border-none drop-shadow-sm">
-      <CardHeader className="flex space-y-2 lg:space-y-0 lg:flex-row lg:items-center justify-between">
+      <CardHeader className="flex flex-col space-y-2 lg:space-y-0 lg:flex-row lg:items-center justify-between">
         <CardTitle className="text-xl line-clamp-1">Categories</CardTitle>
-        <Select defaultValue={chartType} onValueChange={onTypeChange}>
-          <SelectTrigger className="lg:w-auto h-9 rounded-md px-3">
-            <SelectValue placeholder="Chart type" />
-          </SelectTrigger>
+        <div className="flex gap-2">
+          <Select defaultValue={chartType} onValueChange={onTypeChange}>
+            <SelectTrigger className="lg:w-auto h-9 rounded-md px-3">
+              <SelectValue placeholder="Chart type" />
+            </SelectTrigger>
 
-          <SelectContent>
-            <SelectItem value="pie">
-              <div className="flex items-center">
-                <PieChart className="size-4 mr-2 shrink-0" />
-                <p className="line-clamp-1">Pie Chart</p>
-              </div>
-            </SelectItem>
-            <SelectItem value="radar">
-              <div className="flex items-center">
-                <Radar className="size-4 mr-2 shrink-0" />
-                <p className="line-clamp-1">Radar Chart</p>
-              </div>
-            </SelectItem>
-            <SelectItem value="radial">
-              <div className="flex items-center">
-                <Target className="size-4 mr-2 shrink-0" />
-                <p className="line-clamp-1">Radial Chart</p>
-              </div>
-            </SelectItem>
-          </SelectContent>
-        </Select>
+            <SelectContent>
+              <SelectItem value="pie">
+                <div className="flex items-center">
+                  <PieChart className="size-4 mr-2 shrink-0" />
+                  <p className="line-clamp-1">Pie Chart</p>
+                </div>
+              </SelectItem>
+              <SelectItem value="radar">
+                <div className="flex items-center">
+                  <Radar className="size-4 mr-2 shrink-0" />
+                  <p className="line-clamp-1">Radar Chart</p>
+                </div>
+              </SelectItem>
+              <SelectItem value="radial">
+                <div className="flex items-center">
+                  <Target className="size-4 mr-2 shrink-0" />
+                  <p className="line-clamp-1">Radial Chart</p>
+                </div>
+              </SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Select defaultValue={palette} onValueChange={onPaletteChange}>
+            <SelectTrigger className="lg:w-auto h-9 rounded-md px-3">
+              <SelectValue placeholder="Palette" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(CHART_PALETTES).map(([key, colors]) => (
+                <SelectItem key={key} value={key}>
+                  <div className="flex items-center gap-2">
+                    <div className="flex">
+                      {colors.map((c) => (
+                        <span
+                          key={c}
+                          className="w-3 h-3 rounded-full mr-1 last:mr-0"
+                          style={{ backgroundColor: c }}
+                        />
+                      ))}
+                    </div>
+                    <span className="capitalize">{key}</span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </CardHeader>
 
       <CardContent>
@@ -70,9 +102,15 @@ export const SpendingPie = ({ data = [] }: Props) => {
           </div>
         ) : (
           <>
-            {chartType === "pie" && <PieVariant data={data} />}
-            {chartType === "radar" && <RadarVariant data={data} />}
-            {chartType === "radial" && <RadialVariant data={data} />}
+            {chartType === "pie" && (
+              <PieVariant data={data} colors={CHART_PALETTES[palette]} />
+            )}
+            {chartType === "radar" && (
+              <RadarVariant data={data} color={CHART_PALETTES[palette][0]} />
+            )}
+            {chartType === "radial" && (
+              <RadialVariant data={data} colors={CHART_PALETTES[palette]} />
+            )}
           </>
         )}
       </CardContent>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: "jsdom",
+  transform: {
+    "^.+\\.(ts|tsx)$": "babel-jest",
+  },
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/$1",
+  },
+  setupFilesAfterEnv: [],
+};

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "tailwindcss": "^3.4.1",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "react-test-renderer": "^18.2.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Summary
- share chart color palettes across variants
- allow Pie, Radial and Radar charts to accept colors
- add palette selector to SpendingPie
- provide Jest config and a basic unit test for palettes

## Testing
- `npm run typecheck` *(fails: Cannot find module 'clsx', ...)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bd9e24ec832b821e1bdc6f15f496